### PR TITLE
Check for empty retry config

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -101,7 +101,15 @@ type retryConfig struct {
 }
 
 func getRetryConfig(retryConfigs interface{}) retryConfig {
-	flattenedRetryConfigs := retryConfigs.(*schema.Set).List()[0].(map[string]interface{})
+	retrySet := retryConfigs.(*schema.Set).List()
+	if len(retrySet) == 0 {
+		return retryConfig{
+			count:    0,
+			waitTime: 0,
+		}
+	}
+
+	flattenedRetryConfigs := retrySet[0].(map[string]interface{})
 
 	return retryConfig{
 		count:    flattenedRetryConfigs[utils.TerraformResourceCount].(int),


### PR DESCRIPTION
I've found a bug in the provider where it crashes if you don't provide a `retries` block in the provider config. Stack trace below:

```
Stack trace from the terraform-provider-gocd_v0.1.0 plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 24 [running]:
github.com/nikhilsbhat/terraform-provider-gocd/pkg/client.getRetryConfig(...)
        github.com/nikhilsbhat/terraform-provider-gocd/pkg/client/client.go:104
github.com/nikhilsbhat/terraform-provider-gocd/pkg/client.GetGoCDClient({0x10490bae2?, 0x6?}, 0x1400038ca80)
        github.com/nikhilsbhat/terraform-provider-gocd/pkg/client/client.go:76 +0x670
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0x14000282690, {0x104c68430, 0x140003892f0}, 0x140003964b0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/provider.go:369 +0x1d0
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0x1400034e5b8, {0x104c68430?, 0x14000388d50?}, 0x140003c4200)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/grpc_provider.go:618 +0x368
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0x14000279540, {0x104c68430?, 0x140003884b0?}, 0x14000396280)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/tf5server/server.go:587 +0x2ac
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0x104c37300, 0x14000279540}, {0x104c68430, 0x140003884b0}, 0x1400038c100, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:557 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001b6e00, {0x104c68430, 0x140003882d0}, {0x104c6d460, 0x1400017e000}, 0x14000294120, 0x1400037c330, 0x105252ef0, 0x0)
        google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
google.golang.org/grpc.(*Server).handleStream(0x140001b6e00, {0x104c6d460, 0x1400017e000}, 0x14000294120)
        google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 23
        google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c

Error: The terraform-provider-gocd_v0.1.0 plugin crashed
```


Traced the problem back to this code which tries to pull out the retries config without checking if it exists first. Added a check to default the values of `count` and `wait_time` to zero if they aren't defined, and it's fixed my problem. Plan now goes ahead without a problem.

I've also done a regression test to make sure that it still works as expected _with_ the retries block.

With a retry block like this:
```
retries {
    count = 1
    wait_time = 30
  }
```

Output shows it's setting them as expected:
```
2025-03-17T11:57:17.939Z [INFO]  provider.terraform-provider-gocd: 2025/03/17 11:57:17 setting API retry count to 1:: timestamp=2025-03-17T11:57:17.939Z
2025-03-17T11:57:17.939Z [INFO]  provider.terraform-provider-gocd: 2025/03/17 11:57:17 setting API retry wait time to 30:: timestamp=2025-03-17T11:57:17.939Z
```